### PR TITLE
Set sensor state to 0 if the inverter returns 'null' in a data field.

### DIFF
--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -213,6 +213,8 @@ class FroniusSensor(Entity):
                 self._state = round(state / 1000, 2)
             else:
                 self._state = round(state, 2)
+        else:
+            self._state = 0
 
 class InverterData:
     """Handle Fronius API object and limit updates."""


### PR DESCRIPTION
My inverter is finally online :)
I have a smart meter and I have configured the inverter to always log data because I want my family to become aware of how much energy we consume. So at the end of the sunny part of the day when the panels doesn't generate any power the inverter will return 'null' for P_PV because the inverter part has gone into standby while the logger is still active and returning data.
Since the code skipped doing anything with the state if it is 'None' that sensor (fronius_panel_status) would be stuck at the last valid value that was fetched before it stopped producing.
With this change the state is set to 0.

The other two changes are leftovers from when I changed the error handling that you merged manually.