### PR TITLE
Bugfixes for sensor setup and state conversion

### DIFF
--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -213,6 +213,8 @@ class FroniusSensor(Entity):
                 self._state = round(state / 1000, 2)
             else:
                 self._state = round(state, 2)
+        else:
+            self._state = 0
 
 class InverterData:
     """Handle Fronius API object and limit updates."""

--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -41,7 +41,7 @@ SENSOR_TYPES = {
     'year_energy': ['inverter', True, 'YEAR_ENERGY', 'Year Energy', 'MWh', 'energy', 'mdi:solar-power'],
     'total_energy': ['inverter', True, 'TOTAL_ENERGY', 'Total Energy', 'MWh', 'energy', 'mdi:solar-power'],
     'ac_power': ['inverter', True, 'PAC', 'AC Power', 'W', 'power', 'mdi:solar-power'],
-    'day_energy': ['inverter', True, 'DAY_ENERGY', 'Day Energy', 'kWh', False, 'mdi:solar-power'],
+    'day_energy': ['inverter', True, 'DAY_ENERGY', 'Day Energy', 'kWh', 'energy', 'mdi:solar-power'],
     'ac_current': ['inverter', False, 'IAC', 'AC Current', 'A', False, 'mdi:solar-power'],
     'ac_voltage': ['inverter', False, 'UAC', 'AC Voltage', 'V', False, 'mdi:solar-power'],
     'ac_frequency': ['inverter', False, 'FAC', 'AC Frequency', 'Hz', False, 'mdi:solar-power'],
@@ -101,21 +101,24 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
         device = SENSOR_TYPES[variable][0]
         system = SENSOR_TYPES[variable][1]
+        sensor_units = SENSOR_TYPES[variable][4]
         convert_units = SENSOR_TYPES[variable][5]
 
         if convert_units == 'power':
-            units = power_units
+            sensor_units = power_units
+        elif convert_units == 'energy':
+            sensor_units = units
 
         sensor = "sensor." + name + "_" + SENSOR_TYPES[variable][3]
         state = hass.states.get(sensor)
     
         if device == "inverter":
-            if scope == 'System' and system:
-                dev.append(FroniusSensor(inverter_data, name, variable, scope, units, device_id, powerflow))
-            elif  scope == 'Device':
-                dev.append(FroniusSensor(inverter_data, name, variable, scope, units, device_id, powerflow))
+            _LOGGER.debug("Adding inverter sensor: {}, {}, {}, {}, {}, {}, {}".format(inverter_data, name, variable, scope, sensor_units, device_id, powerflow))
+            dev.append(FroniusSensor(inverter_data, name, variable, scope, sensor_units, device_id, powerflow))
+            
         elif device == "powerflow" and powerflow:
-            dev.append(FroniusSensor(powerflow_data, name, variable, scope, units, device_id, powerflow))
+            _LOGGER.debug("Adding powerflow sensor: {}, {}, {}, {}, {}, {}, {}".format(inverter_data, name, variable, scope, sensor_units, device_id, powerflow))
+            dev.append(FroniusSensor(powerflow_data, name, variable, scope, sensor_units, device_id, powerflow))
 
     async_add_entities(dev, True)
 
@@ -196,25 +199,27 @@ class FroniusSensor(Entity):
         # convert and round the result
         if state is not None:
             if self._convert_units == "energy":
+                _LOGGER.debug("Converting energy ({}) to {}".format(state, self._units))
                 if self._units == "MWh":
                     self._state = round(state / 1000000, 2)
                 elif self._units == "kWh":
                     self._state = round(state / 1000, 2)
                 else:
                     self._state = round(state, 2)
-            if self._convert_units == "power":
+            elif self._convert_units == "power":
+                _LOGGER.debug("Converting power ({}) to {}".format(state, self._units))
                 if self._units == "MW":
                     self._state = round(state / 1000000, 2)
                 elif self._units == "kW":
                     self._state = round(state / 1000, 2)
                 else:
                     self._state = round(state, 2)
-            elif self._json_key == "DAY_ENERGY":
-                self._state = round(state / 1000, 2)
             else:
+                _LOGGER.debug("Rounding ({}) to two decimals".format(state))
                 self._state = round(state, 2)
         else:
             self._state = 0
+        _LOGGER.debug("State converted ({})".format(self._state))
 
 class InverterData:
     """Handle Fronius API object and limit updates."""


### PR DESCRIPTION
After setting up things in HA I noticed that there were some issues with the DAY_ENERGY reading. It was shown as having unit 'W' and the value was not converted to 'kWh' as the other energy values. Yet all the energy values, as returned by the Fronius API are in Wh.

So I have made the following changes:
- Changed the DAY_ENERGY sensor the be of type 'energy'.
- Modified the logic for how the state is converted.
- Fixed a bug where all sensors created after the first power sensor got the power_unit as unit type.

With these changes the sensors looks ok and the values are converted as I believe that they should be.