### PR TITLE
Add support for sensors from the SmartMeter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 
 # Fronius Sensor for Home Assistant
-This component simplifies the integration of a Fronius inverter and optional PowerFlow:
-* creates up to 12 individual sensors for easy display or use in automations
+This component simplifies the integration of a Fronius inverter and optional PowerFlow and SmartMeter:
+* creates up to 24 individual sensors for easy display or use in automations
 * converts Wh to kWh
 * rounds values to 2 decimal places
 * converts daily, yearly and total energy data to kWh or MWh (user-configurable)
@@ -18,6 +18,8 @@ This component simplifies the integration of a Fronius inverter and optional Pow
 The Default URL called is ``http://ip_address/GetInverterRealtimeData.cgi?Scope=Device&DeviceId=1&DataCollection=CommonInverterData``
 
 The optional PowerFlow URL is ``http://ip_address/solar_api/v1/GetPowerFlowRealtimeData.fcgi``
+
+The optional SmartMeter URL is ``http://ip_address/solar_api/v1/GetMeterRealtimeData.cgi?Scope=Device&DeviceId=1``
 
 ### Installation
 Copy the ``fronius_inverter`` folder in the custom_components directory into your own custom_components directory in your config directory of Home Assistant.
@@ -68,13 +70,22 @@ sensor:
     power_units: kW
 ```
 
+```yaml
+# Example configuration.yaml entry where you have a SmartMeter device:
+sensor:
+  - platform: fronius_inverter
+    ip_address: LOCAL_IP_FOR_FRONIUS
+    smartmeter: True
+```
+
 ### Configuration Variables
 
 variable | required | type | default | description
 -------- | -------- | ---- | ------- | -----------
 ``ip_address`` | yes | string | | The local IP address of your Fronius Inverter.
 ``name`` | no | string | ``Fronius`` | The preferred name of your Fronius Inverter.
-``powerflow`` | no | boolean | ``False`` | Set to ``True`` if you have a PowerFlow meter to add ``grid_usage``, ``house_load`` and ``panel_status`` sensors.
+``powerflow`` | no | boolean | ``False`` | Set to ``True`` if you have a PowerFlow meter (SmartMeter) to add ``grid_usage``, ``house_load`` and ``panel_status`` sensors.
+``smartmeter`` | no | boolean | ``False`` | Set to ``True`` if you have a SmartMeter to add sensors for grid AC current/voltage and total energy sold/consumed.
 ``units`` | no | string | ``MWh`` | The preferred units for Year and Total Energy from ``Wh, kWh, MWh``.
 ``power_units`` | no | string | ``W`` | The preferred PowerFlow units from ``W, kW, MW``.
 ``device_id`` | no | string | ``1`` | The Device ID of your Fronius Inverter.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ variable | required | type | default | description
 ``name`` | no | string | ``Fronius`` | The preferred name of your Fronius Inverter.
 ``powerflow`` | no | boolean | ``False`` | Set to ``True`` if you have a PowerFlow meter (SmartMeter) to add ``grid_usage``, ``house_load`` and ``panel_status`` sensors.
 ``smartmeter`` | no | boolean | ``False`` | Set to ``True`` if you have a SmartMeter to add sensors for grid AC current/voltage and total energy sold/consumed.
+``smartmeter_device_id`` | no | string | ``0`` | The Device ID of your Fronius SmartMeter.
 ``units`` | no | string | ``MWh`` | The preferred units for Year and Total Energy from ``Wh, kWh, MWh``.
 ``power_units`` | no | string | ``W`` | The preferred PowerFlow units from ``W, kW, MW``.
 ``device_id`` | no | string | ``1`` | The Device ID of your Fronius Inverter.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This component simplifies the integration of a Fronius inverter and optional Pow
 * rounds values to 2 decimal places
 * converts daily, yearly and total energy data to kWh or MWh (user-configurable)
 * optionally connects to PowerFlow devices for 3 additional sensors
+* optionally connects to SmartMeter devices for 10 additional sensors
 * optionally converts PowerFlow units to W, kW or MW
 * optionally sums values if you have more than one inverter
 * compatible with the custom [Power Wheel Card](https://github.com/gurbyz/power-wheel-card/tree/master) if using PowerFlow

--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -213,6 +213,8 @@ class FroniusSensor(Entity):
                 self._state = round(state / 1000, 2)
             else:
                 self._state = round(state, 2)
+        else:
+            self._state = 0
 
 class InverterData:
     """Handle Fronius API object and limit updates."""

--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -62,7 +62,11 @@ SENSOR_TYPES = {
     'smartmeter_current_ac_phase_three': ['smartmeter', False, 'Current_AC_Phase_3', 'SmartMeter Current AC Phase 3', 'A', False, 'mdi:solar-power'],
     'smartmeter_voltage_ac_phase_one': ['smartmeter', False, 'Voltage_AC_Phase_1', 'SmartMeter Voltage AC Phase 1', 'V', False, 'mdi:solar-power'],
     'smartmeter_voltage_ac_phase_two': ['smartmeter', False, 'Voltage_AC_Phase_2', 'SmartMeter Voltage AC Phase 2', 'V', False, 'mdi:solar-power'],
-    'smartmeter_voltage_ac_phase_three': ['smartmeter', False, 'Voltage_AC_Phase_3', 'SmartMeter Voltage AC Phase 3', 'V', False, 'mdi:solar-power']
+    'smartmeter_voltage_ac_phase_three': ['smartmeter', False, 'Voltage_AC_Phase_3', 'SmartMeter Voltage AC Phase 3', 'V', False, 'mdi:solar-power'],
+    'smartmeter_energy_ac_absolute_plus': ['smartmeter', False, 'EnergyReal_WAC_Plus_Absolute', 'SmartMeter Energy AC Absolute Plus', 'Wh', 'energy', 'mdi:solar-power'],
+    'smartmeter_energy_ac_absolute_minus': ['smartmeter', False, 'EnergyReal_WAC_Minus_Absolute', 'SmartMeter Energy AC Absolute Minus', 'Wh', 'energy', 'mdi:solar-power'],
+    'smartmeter_energy_ac_consumed': ['smartmeter', False, 'EnergyReal_WAC_Sum_Consumed', 'SmartMeter Energy AC Consumed', 'Wh', 'energy', 'mdi:solar-power'],
+    'smartmeter_energy_ac_sold': ['smartmeter', False, 'EnergyReal_WAC_Sum_Produced', 'SmartMeter Energy AC Sold', 'Wh', 'energy', 'mdi:solar-power']
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
This pull request adds optional support for querying the SmartMeter API endpoint in the Fronius Inverter.
It will add 10 more sensors for monitoring Grid AC Current/Voltage and total consumed/sold energy from the grid.

For more information you can also check this post in the Home Assistant forum:
https://community.home-assistant.io/t/fronius-inverter-integration/19274/214