### PR TITLE
Decrease MIN_TIME_BETWEEN_UPDATES from 60 to 10

### DIFF
--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -39,7 +39,7 @@ SCOPE_TYPES = ['Device', 'System']
 UNIT_TYPES = ['Wh', 'kWh', 'MWh']
 POWER_UNIT_TYPES = ['W', 'kW', 'MW']
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
 # Key: ['device', 'system', 'json_key', 'name', 'unit', 'convert_units', 'icon']
 SENSOR_TYPES = {


### PR DESCRIPTION
I tested it with my Fronius Symo. I can call the API with curl once a second without any problems. But my S0 meter powerflow data is only updated every ~10 seconds (at least on low house load). So lowering to 10 seconds is sufficient for me.