### PR TITLE
Added new config option 'always_log'

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ variable | required | type | default | description
 -------- | -------- | ---- | ------- | -----------
 ``ip_address`` | yes | string | | The local IP address of your Fronius Inverter.
 ``name`` | no | string | ``Fronius`` | The preferred name of your Fronius Inverter.
+``always_log`` | no | boolean | ``True`` | Set to ``False`` if your Fronius Inverter shuts down when the sun goes down.
 ``scan_interval`` | no | string | 60 | The interval to query the Fronius Inverter for data.
 ``powerflow`` | no | boolean | ``False`` | Set to ``True`` if you have a PowerFlow meter (SmartMeter) to add ``grid_usage``, ``house_load``, ``panel_status``, ``rel_autonomy`` and ``rel_selfconsumption`` sensors.
 ``smartmeter`` | no | boolean | ``False`` | Set to ``True`` if you have a SmartMeter to add ``smartmeter_current_ac_phase_one``, ``smartmeter_current_ac_phase_two``, ``smartmeter_current_ac_phase_three``, ``smartmeter_voltage_ac_phase_one``, ``smartmeter_voltage_ac_phase_two``, ``smartmeter_voltage_ac_phase_three``, ``smartmeter_energy_ac_consumed`` and ``smartmeter_energy_ac_sold`` sensors.

--- a/info.md
+++ b/info.md
@@ -8,7 +8,7 @@ This component simplifies the integration of a Fronius inverter and optional Sma
 * converts yearly and total energy data to kWh or MWh (user-configurable)
 * optionally connects to your smart meter (PowerFlow) device for 3 additional sensors
 * optionally sums values if you have more than one inverter
-* pauses from sunset to sunrise to handle inverter logging going offline at night
+* optionally pauses from sunset to sunrise to handle inverter logging going offline at night (always_log: false)
 
 ### Minimal Configuration
 ```


### PR DESCRIPTION
This pull request aims to adress both the issue that was introduced by merging #45 and the original idea (from d5b50977, that never enabled the feature) to stop polling the inverter between sunset and sunrise when it is no longer producing power (the default behavior of the Fronius datalogger).

By default this patch will re-enable the old behavior (pre merging #45) where the integration is always polling the datalogger (i.e. no change needed to any configuration). But if the user has the datalogger set to shutdown when the inverter is no longer producing power they can add a new config option "always_log: false". This will change the integration to stop polling when the sun is down to minimize errors in the home-assistant log.