### PR TITLE
Support for Gen24 inverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This component simplifies the integration of a Fronius inverter and optional Pow
 * rounds values to 2 decimal places
 * converts yearly and total energy data to kWh or MWh (user-configurable)
 * optionally sums values if you have more than one inverter
+* supports the new Gen24 inverter (some sensors differs from Symo)
 
 If you have a SmartMeter installed this component:
 * optionally connects to PowerFlow API for 5 additional sensors
@@ -91,6 +92,7 @@ variable | required | type | default | description
 -------- | -------- | ---- | ------- | -----------
 ``ip_address`` | yes | string | | The local IP address of your Fronius Inverter.
 ``name`` | no | string | ``Fronius`` | The preferred name of your Fronius Inverter.
+``model`` | no | string | ``symo`` | Type of inverter from ``gen24, symo``
 ``always_log`` | no | boolean | ``True`` | Set to ``False`` if your Fronius Inverter shuts down when the sun goes down.
 ``scan_interval`` | no | string | 60 | The interval to query the Fronius Inverter for data.
 ``powerflow`` | no | boolean | ``False`` | Set to ``True`` if you have a PowerFlow meter (SmartMeter) to add ``grid_usage``, ``house_load``, ``panel_status``, ``rel_autonomy`` and ``rel_selfconsumption`` sensors.

--- a/custom_components/fronius_inverter/manifest.json
+++ b/custom_components/fronius_inverter/manifest.json
@@ -5,5 +5,5 @@
   "dependencies": [],
   "codeowners": ["@safepay"],
   "requirements": [],
-  "version": "v0.9.6"
+  "version": "v0.9.7"
 }


### PR DESCRIPTION
This patch will add support for reading sensor values from the Gen24 inverter.
Unfortunately Fronius did not obey to their own API in Gen24 so all the smartmeter sensors have new names. This patch fixes that. 
See README for information about the new configuration option `model`.

There are still issues with the Gen24 in that DAY_ENERGY, YEAR_ENERGY & TOTAL_ENERGY are null. But with the exception of TOTAL_ENERGY that is what Fronius has documented. For TOTAL_ENERGY they say that it should be present in FW 1.14.0. But Fronius has not released any FW newer than 1.12.5.

The patch has been tested by two people in #58 