### PR TITLE
Update readme with unit requirement for Energy dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ All energy and power sensors provide required attributes to allow long term stat
 * Grid consumption: ``smartmeter_energy_ac_consumed``
 * Grid feed-in: ``smartmeter_energy_ac_sold``
 
+> **_NOTE:_**  The Energy dashboard expects units to be expressed in kWh otherwise they will not be available to add to the configuration. To resolve this, you must include the following in the Fronius component configuration.yaml entry to ensure units are converted appropriately:
+>
+>``units: kWh``
+
 ### URL's Utilised
 The Default URL called is ``http://ip_address/GetInverterRealtimeData.cgi?Scope=Device&DeviceId=1&DataCollection=CommonInverterData``
 


### PR DESCRIPTION
Quick update to add this vital info to the readme--without a _unit: kWh_ line added to configuration.yaml, the entities don't appear in the Energy dashboard settings as expected.