### PR TITLE
Add 'battery_usage' sensor to powerflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ variable | required | type | default | description
 ``model`` | no | string | ``symo`` | Type of inverter from ``gen24, symo``
 ``always_log`` | no | boolean | ``True`` | Set to ``False`` if your Fronius Inverter shuts down when the sun goes down.
 ``scan_interval`` | no | string | 60 | The interval to query the Fronius Inverter for data.
-``powerflow`` | no | boolean | ``False`` | Set to ``True`` if you have a PowerFlow meter (SmartMeter) to add ``grid_usage``, ``house_load``, ``panel_status``, ``rel_autonomy`` and ``rel_selfconsumption`` sensors.
+``powerflow`` | no | boolean | ``False`` | Set to ``True`` if you have a PowerFlow meter (SmartMeter) to add ``battery_usage``, ``grid_usage``, ``house_load``, ``panel_status``, ``rel_autonomy`` and ``rel_selfconsumption`` sensors.
 ``smartmeter`` | no | boolean | ``False`` | Set to ``True`` if you have a SmartMeter to add ``smartmeter_current_ac_phase_one``, ``smartmeter_current_ac_phase_two``, ``smartmeter_current_ac_phase_three``, ``smartmeter_voltage_ac_phase_one``, ``smartmeter_voltage_ac_phase_two``, ``smartmeter_voltage_ac_phase_three``, ``smartmeter_energy_ac_consumed`` and ``smartmeter_energy_ac_sold`` sensors.
 ``smartmeter_device_id`` | no | string | ``0`` | The Device ID of your Fronius SmartMeter.
 ``units`` | no | string | ``MWh`` | The preferred units for Year and Total Energy from ``Wh, kWh, MWh``.

--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -64,6 +64,7 @@ SENSOR_TYPES = {
     'ac_frequency': ['inverter', False, 'FAC', 'AC Frequency', 'Hz', False, 'mdi:solar-power'],
     'dc_current': ['inverter', False, 'IDC', 'DC Current', 'A', False, 'mdi:solar-power'],
     'dc_voltage': ['inverter', False, 'UDC', 'DC Voltage', 'V', False, 'mdi:solar-power'],
+    'battery_usage': ['powerflow', False, 'P_Akku', 'Battery Usage', 'W', 'power', 'mdi:home-battery'],
     'grid_usage': ['powerflow', False, 'P_Grid', 'Grid Usage', 'W', 'power', 'mdi:solar-power'],
     'house_load': ['powerflow', False, 'P_Load', 'House Load', 'W', 'power', 'mdi:solar-power'],
     'panel_status': ['powerflow', False, 'P_PV', 'Panel Status', 'W', 'power', 'mdi:solar-panel'],


### PR DESCRIPTION
Battery usage reports as `P_Akku` via GetPowerFlowRealtimeData.fcgi.

There are a number of other battery related properties reported in the same API, but I wasn't sure how you'd like them implemented. We may also want to hide them behind a config option.

`Body.Data.Inverters.[id]` has some data that would be useful to include: `Battery_Mode`, `SOC` (state of charge)

Below is a sample response:
```json
{
    "Body": {
        "Data": {
            "Inverters": {
                "1": {
                    "Battery_Mode": "nearly depleted",
                    "DT": 1,
                    "E_Day": null,
                    "E_Total": 33524.319722222222,
                    "E_Year": null,
                    "P": 1120.3355712890625,
                    "SOC": 45.0
                }
            },
            "Site": {
                "BackupMode": true,
                "BatteryStandby": false,
                "E_Day": null,
                "E_Total": 33524.319722222222,
                "E_Year": null,
                "Meter_Location": "grid",
                "Mode": "bidirectional",
                "P_Akku": -11.14264965057373,
                "P_Grid": 673.12,
                "P_Load": -1795.8200732421874,
                "P_PV": 1219.5472106933594,
                "rel_Autonomy": 62.517403050031405,
                "rel_SelfConsumption": 100.0
            },
            "Smartloads": {
                "Ohmpilots": { }
            },
            "Version": "12"
        }
    },
    "Head": {
        "RequestArguments": { },
        "Status": {
            "Code": 0,
            "Reason": "",
            "UserMessage": ""
        },
        "Timestamp": "2021-11-21T04:05:52+00:00"
    }
}
```