### PR TITLE
Change state attribute naming (based on 2021.12 deprecation)

### DIFF
--- a/custom_components/fronius_inverter/sensor.py
+++ b/custom_components/fronius_inverter/sensor.py
@@ -260,7 +260,7 @@ class FroniusSensor(SensorEntity):
             return self._unit
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
         return attrs


### PR DESCRIPTION
Remove deprecated `"device_state_attributes"` property in favor of `"extra_state_attributes"`. 

Fixes Log Warnings produced in Home Assistant 2021.12+

This is unlikely to cause issues for users running older versions of Home Assistant, (unless it's older than 2021.4).
https://github.com/home-assistant/core/pull/47304
